### PR TITLE
Fix exit() argument in the Assembly part

### DIFF
--- a/cursed-k8s-x86/cursed.yaml.s
+++ b/cursed-k8s-x86/cursed.yaml.s
@@ -35,5 +35,5 @@ spec:
     kube9:
       syscall
       mov   $0x02000001, %rax
-      xor   $0, %rdi
+      xor   %rdi, %rdi
       syscall


### PR DESCRIPTION
xor $0, %rdi is a no-op.
xor %rdi, %rdi (or mov $0, %rdi) will properly set exit code to 0.